### PR TITLE
Allow caller override the UIBarButtonItem - Swift 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ Customize the action button image of the right menu bar item
 controller.actionButtonImage = UIImage(named: "printButtonImage")
 ```
 
+Customize the action button by replacing the UIBarButtonItem displayed with your own
+```swift
+controller.actionButton = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(myController.sharePDF(_:)))
+```        
+
 ## Acknowledgements
 
 inspired by PDF Reader https://github.com/vfr/Reader and Apple's example on TiledScrollView

--- a/Sources/Classes/PDFViewController.swift
+++ b/Sources/Classes/PDFViewController.swift
@@ -21,6 +21,8 @@ public final class PDFViewController: UIViewController {
     
     /// Image used to override the default action button image
     public var actionButtonImage: UIImage?
+    /// UIBarButtonItem used to override the default action button
+    public var actionButton: UIBarButtonItem?
     
     fileprivate var currentPageIndex: Int = 0
     fileprivate var thumbnailCollectionController: PDFThumbnailCollectionViewController?
@@ -31,13 +33,15 @@ public final class PDFViewController: UIViewController {
         super.viewDidLoad()
         collectionView!.register(PDFPageCollectionViewCell.self, forCellWithReuseIdentifier: "page")
         
-        let actionButton: UIBarButtonItem
-        if let actionButtonImage = actionButtonImage {
-            actionButton = UIBarButtonItem(image: actionButtonImage, style: .plain, target: self, action: #selector(print))
-        } else {
-            actionButton = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(print))
+        if actionButton == nil {
+            if let actionButtonImage = actionButtonImage {
+                actionButton = UIBarButtonItem(image: actionButtonImage, style: .plain, target: self, action: #selector(print))
+            } else {
+                actionButton = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(print))
+            }
         }
-        navigationItem.rightBarButtonItem = actionButton
+        
+        navigationItem.rightBarButtonItem = actionButton!
         
         let numberOfPages = CGFloat(document.pageCount)
         let cellSpacing = CGFloat(2.0)


### PR DESCRIPTION
Expose actionButton to allow the caller to override with their own UIBarButtonItem.
