### PR TITLE
Added background color customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ PDFViewController.createNew(with: document, title: "Favorite Cupcakes")
 
 #### Background Color
 ```swift
-controller.setBackgroundColor(to: UIColor.white)
+controller.backgroundColor = .white
 ```
 
 #### Action Button Image and Action

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ navigationController?.pushViewController(readerController, animated: true)
 PDFViewController.createNew(with: document, title: "Favorite Cupcakes")
 ```
 
+#### Background Color
+```swift
+controller.setBackgroundColor(to: UIColor.white)
+```
+
 #### Action Button Image and Action
 
 ##### Available Action Styles

--- a/Sources/Assets/PDFReader.storyboard
+++ b/Sources/Assets/PDFReader.storyboard
@@ -19,7 +19,6 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="xgz-br-S4l">
-                                <color key="backgroundColor" red="0.92549019607843142" green="0.93725490196078431" blue="0.94509803921568625" alpha="1" colorSpace="calibratedRGB"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="1" minimumInteritemSpacing="0.0" id="UBd-Nd-OUA">
                                     <size key="itemSize" width="50" height="50"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>

--- a/Sources/Assets/PDFReader.storyboard
+++ b/Sources/Assets/PDFReader.storyboard
@@ -1,6 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="16A319" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="iqd-FA-oQ4">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="iqd-FA-oQ4">
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,6 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="xgz-br-S4l">
+                                <color key="backgroundColor" red="0.92549019607843142" green="0.93725490196078431" blue="0.94509803921568625" alpha="1" colorSpace="calibratedRGB"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="1" minimumInteritemSpacing="0.0" id="UBd-Nd-OUA">
                                     <size key="itemSize" width="50" height="50"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>

--- a/Sources/Classes/PDFViewController.swift
+++ b/Sources/Classes/PDFViewController.swift
@@ -84,19 +84,17 @@ public final class PDFViewController: UIViewController {
     /// UIBarButtonItem used to override the default action button
     fileprivate var actionButton: UIBarButtonItem?
     
-    /// Background color to apply to both the view and the collectionView.
-    public var backgroundColor: UIColor? {
-        get {
-            return collectionView.backgroundColor
-        } set (color) {
-            view.backgroundColor = color
-            collectionView.backgroundColor = color
+    /// Background color to apply to the collectionView.
+    public var backgroundColor: UIColor? = .lightGray {
+        didSet {
+            collectionView?.backgroundColor = backgroundColor
         }
     }
     
     override public func viewDidLoad() {
         super.viewDidLoad()
-        
+    
+        collectionView.backgroundColor = backgroundColor
         collectionView.register(PDFPageCollectionViewCell.self, forCellWithReuseIdentifier: "page")
         
         navigationItem.rightBarButtonItem = actionButton

--- a/Sources/Classes/PDFViewController.swift
+++ b/Sources/Classes/PDFViewController.swift
@@ -84,18 +84,21 @@ public final class PDFViewController: UIViewController {
     /// UIBarButtonItem used to override the default action button
     fileprivate var actionButton: UIBarButtonItem?
     
-    /// Default background color applied both to the view and the collectionView.
-    fileprivate var defaultBackgroundColor: UIColor {
-        return UIColor(red: 236/255, green: 239/255, blue: 241/255, alpha: 1)
+    /// Background color to apply to both the view and the collectionView.
+    var backgroundColor: UIColor = UIColor(red: 236/255, green: 239/255, blue: 241/255, alpha: 1) {
+        didSet {
+            view.backgroundColor = backgroundColor
+            collectionView.backgroundColor = backgroundColor
+        }
     }
     
     override public func viewDidLoad() {
         super.viewDidLoad()
         
-        self.view.backgroundColor = defaultBackgroundColor
+        self.view.backgroundColor = backgroundColor
         
-        collectionView?.backgroundColor = defaultBackgroundColor
-        collectionView?.register(PDFPageCollectionViewCell.self, forCellWithReuseIdentifier: "page")
+        collectionView.backgroundColor = backgroundColor
+        collectionView.register(PDFPageCollectionViewCell.self, forCellWithReuseIdentifier: "page")
         
         navigationItem.rightBarButtonItem = actionButton
         
@@ -172,15 +175,6 @@ public final class PDFViewController: UIViewController {
     }
 }
 
-//MARK: Customization
-extension PDFViewController {
-    public func setBackgroundColor(to color: UIColor) {
-        collectionView?.backgroundColor = color
-        self.view.backgroundColor = color
-    }
-}
-
-//MARK: Delegates
 extension PDFViewController: PDFThumbnailControllerDelegate {
     func didSelectIndexPath(_ indexPath: IndexPath) {
         collectionView.scrollToItem(at: indexPath, at: .left, animated: false)

--- a/Sources/Classes/PDFViewController.swift
+++ b/Sources/Classes/PDFViewController.swift
@@ -84,8 +84,17 @@ public final class PDFViewController: UIViewController {
     /// UIBarButtonItem used to override the default action button
     fileprivate var actionButton: UIBarButtonItem?
     
+    /// Default background color applied both to the view and the collectionView.
+    fileprivate var defaultBackgroundColor: UIColor {
+        return UIColor(red: 236/255, green: 239/255, blue: 241/255, alpha: 1)
+    }
+    
     override public func viewDidLoad() {
         super.viewDidLoad()
+        
+        self.view.backgroundColor = defaultBackgroundColor
+        
+        collectionView?.backgroundColor = defaultBackgroundColor
         collectionView?.register(PDFPageCollectionViewCell.self, forCellWithReuseIdentifier: "page")
         
         navigationItem.rightBarButtonItem = actionButton
@@ -163,6 +172,15 @@ public final class PDFViewController: UIViewController {
     }
 }
 
+//MARK: Customization
+extension PDFViewController {
+    public func setBackgroundColor(to color: UIColor) {
+        collectionView?.backgroundColor = color
+        self.view.backgroundColor = color
+    }
+}
+
+//MARK: Delegates
 extension PDFViewController: PDFThumbnailControllerDelegate {
     func didSelectIndexPath(_ indexPath: IndexPath) {
         collectionView.scrollToItem(at: indexPath, at: .left, animated: false)

--- a/Sources/Classes/PDFViewController.swift
+++ b/Sources/Classes/PDFViewController.swift
@@ -85,19 +85,18 @@ public final class PDFViewController: UIViewController {
     fileprivate var actionButton: UIBarButtonItem?
     
     /// Background color to apply to both the view and the collectionView.
-    var backgroundColor: UIColor = UIColor(red: 236/255, green: 239/255, blue: 241/255, alpha: 1) {
-        didSet {
-            view.backgroundColor = backgroundColor
-            collectionView.backgroundColor = backgroundColor
+    public var backgroundColor: UIColor? {
+        get {
+            return collectionView.backgroundColor
+        } set (color) {
+            view.backgroundColor = color
+            collectionView.backgroundColor = color
         }
     }
     
     override public func viewDidLoad() {
         super.viewDidLoad()
         
-        self.view.backgroundColor = backgroundColor
-        
-        collectionView.backgroundColor = backgroundColor
         collectionView.register(PDFPageCollectionViewCell.self, forCellWithReuseIdentifier: "page")
         
         navigationItem.rightBarButtonItem = actionButton


### PR DESCRIPTION
While the PDF pages fill the iPad screens nicely, the user is greeted with an ugly, black background on iPhone ones. I took the liberty of changing the default background to a gray-ish color, and added an instance method to allow users to provide their own BG colors.