### PR TITLE
Do not load thumbnails strip at controller creation

### DIFF
--- a/PDFReader/Demo/StartViewController.swift
+++ b/PDFReader/Demo/StartViewController.swift
@@ -55,6 +55,8 @@ internal final class StartViewController: UIViewController {
     /// Presents a document
     ///
     /// - parameter document: document to present
+    ///
+    /// Add `thumbnailsEnabled:false` to `createNew` to not load the thumbnails in the controller.
     fileprivate func showDocument(_ document: PDFDocument) {
         let image = UIImage(named: "")
         let controller = PDFViewController.createNew(with: document, title: "", actionButtonImage: image, actionStyle: .activitySheet)

--- a/Sources/Classes/PDFViewController.swift
+++ b/Sources/Classes/PDFViewController.swift
@@ -198,11 +198,6 @@ extension PDFViewController: UICollectionViewDataSource {
 }
 
 extension PDFViewController: PDFPageCollectionViewCellDelegate {
-    /// Whether or not the thumbnail controller is currently being displayed
-    private var isThumbnailControllerShown: Bool {
-        return thumbnailCollectionControllerBottom.constant == -thumbnailCollectionControllerHeight.constant
-    }
-    
     /// Toggles the hiding/showing of the thumbnail controller
     ///
     /// - parameter shouldHide: whether or not the controller show hide
@@ -211,7 +206,12 @@ extension PDFViewController: PDFPageCollectionViewCellDelegate {
     }
     
     func handleSingleTap(_ cell: PDFPageCollectionViewCell, pdfPageView: PDFPageView) {
-        let shouldHide = !isThumbnailControllerShown
+        var shouldHide: Bool {
+            guard let isNavigationBarHidden = navigationController?.isNavigationBarHidden else {
+                return false
+            }
+            return !isNavigationBarHidden
+        }
         UIView.animate(withDuration: 0.25) {
             self.hideThumbnailController(shouldHide)
             self.navigationController?.setNavigationBarHidden(shouldHide, animated: true)

--- a/Sources/Classes/PDFViewController.swift
+++ b/Sources/Classes/PDFViewController.swift
@@ -94,6 +94,30 @@ public final class PDFViewController: UIViewController {
         }
     }
     
+    /// Set this to `false` if you don't want to load the thumbnails strip.
+    fileprivate var thumbnailsEnabled = true {
+        didSet {
+            if thumbnailCollectionControllerHeight == nil {
+                _ = view
+            }
+            if !thumbnailsEnabled {
+                thumbnailCollectionControllerHeight.constant = 0
+            }
+        }
+    }
+    
+    /// Slides horizontally (from left to right, default) or vertically (from top to bottom)
+    public var scrollDirection: UICollectionViewScrollDirection = .horizontal {
+        didSet {
+            if collectionView == nil {  // if the user of the controller is trying to change the scrollDiecton before it
+                _ = view                // is on the sceen, we need to show it ofscreen to access it's collectionView.
+            }
+            if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
+                layout.scrollDirection = scrollDirection
+            }
+        }
+    }
+    
     override public func viewDidLoad() {
         super.viewDidLoad()
     

--- a/Sources/Classes/PDFViewController.swift
+++ b/Sources/Classes/PDFViewController.swift
@@ -145,6 +145,10 @@ public final class PDFViewController: UIViewController {
         return .slide
     }
     
+    public override func shouldPerformSegue(withIdentifier identifier: String, sender: Any?) -> Bool {
+        return thumbnailsEnabled
+    }
+    
     override public func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let controller = segue.destination as? PDFThumbnailCollectionViewController {
             thumbnailCollectionController = controller

--- a/Sources/Classes/PDFViewController.swift
+++ b/Sources/Classes/PDFViewController.swift
@@ -17,7 +17,7 @@ extension PDFViewController {
     /// - parameter backButton:        button to override the default controller back button
     ///
     /// - returns: a `PDFViewController`
-    public class func createNew(with document: PDFDocument, title: String? = nil, actionButtonImage: UIImage? = nil, actionStyle: ActionStyle = .print, backButton: UIBarButtonItem? = nil) -> PDFViewController {
+    public class func createNew(with document: PDFDocument, title: String? = nil, actionButtonImage: UIImage? = nil, actionStyle: ActionStyle = .print, backButton: UIBarButtonItem? = nil, thumbnailsEnabled: Bool? = true) -> PDFViewController {
         let storyboard = UIStoryboard(name: "PDFReader", bundle: Bundle(for: PDFViewController.self))
         let controller = storyboard.instantiateInitialViewController() as! PDFViewController
         controller.document = document
@@ -30,6 +30,7 @@ extension PDFViewController {
         }
         
         controller.backButton = backButton
+        controller.thumbnailsEnabled = thumbnailsEnabled!
         
         if let actionButtonImage = actionButtonImage {
             controller.actionButton = UIBarButtonItem(image: actionButtonImage, style: .plain, target: controller, action: #selector(actionButtonPressed))


### PR DESCRIPTION
Some apps (like ours) don't want to display the thumbnails. In our case, most documents are 1 to 2 pages, so it doesn't make sense. Also, this way it doesn't have to load an additional controller.