### PR TITLE
Disable Paging / Give public access to collectionView

### DIFF
--- a/Sources/Classes/PDFViewController.swift
+++ b/Sources/Classes/PDFViewController.swift
@@ -56,7 +56,7 @@ public final class PDFViewController: UIViewController {
     }
     
     /// Collection veiw where all the pdf pages are rendered
-    @IBOutlet fileprivate var collectionView: UICollectionView!
+    @IBOutlet public var collectionView: UICollectionView!
     
     /// Height of the thumbnail bar (used to hide/show)
     @IBOutlet fileprivate var thumbnailCollectionControllerHeight: NSLayoutConstraint!


### PR DESCRIPTION
For that, in my opinion, the simplest solution is to give `public` access to the collectionView. We sure could create a property `isPagingEnabled` and keep the `UICollectionView` private, but I think this would be overkill.