### PR TITLE
Ability to change the scrollDirection

### DIFF
--- a/PDFReader/Demo/StartViewController.swift
+++ b/PDFReader/Demo/StartViewController.swift
@@ -58,6 +58,7 @@ internal final class StartViewController: UIViewController {
     fileprivate func showDocument(_ document: PDFDocument) {
         let image = UIImage(named: "")
         let controller = PDFViewController.createNew(with: document, title: "", actionButtonImage: image, actionStyle: .activitySheet)
+        // controller.scrollDirection = .vertical // use this to scroll from top to bottom instead of left to right
         navigationController?.pushViewController(controller, animated: true)
     }
 

--- a/Sources/Classes/PDFViewController.swift
+++ b/Sources/Classes/PDFViewController.swift
@@ -94,6 +94,17 @@ public final class PDFViewController: UIViewController {
         }
     }
     
+    public var scrollDirection: UICollectionViewScrollDirection = .horizontal {
+        didSet {
+            if collectionView == nil {  // if the user of the controller is trying to change the scrollDiecton before it
+                _ = view                // is on the sceen, we need to show it ofscreen to access it's collectionView.
+            }
+            if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
+                layout.scrollDirection = scrollDirection
+            }
+        }
+    }
+    
     override public func viewDidLoad() {
         super.viewDidLoad()
     

--- a/Sources/Classes/PDFViewController.swift
+++ b/Sources/Classes/PDFViewController.swift
@@ -94,6 +94,7 @@ public final class PDFViewController: UIViewController {
         }
     }
     
+    /// Slides horizontally (from left to right, default) or vertically (from top to bottom)
     public var scrollDirection: UICollectionViewScrollDirection = .horizontal {
         didSet {
             if collectionView == nil {  // if the user of the controller is trying to change the scrollDiecton before it


### PR DESCRIPTION
The user might want to display pages in a `vertical` manner in the underlying pages collectionView.

Implemented in a way that casts directly the `layout` so the end user doesn't have to go through the `collectionView`.