### PR TITLE
Bug 64 - Accessing UIKit from background queue

### DIFF
--- a/Sources/Classes/TiledView.swift
+++ b/Sources/Classes/TiledView.swift
@@ -57,6 +57,13 @@ internal final class TiledView: UIView {
     // Draw the CGPDFPage into the layer at the correct scale.
     override func draw(_ layer: CALayer, in con: CGContext) {
         guard let leftPdfPage = leftPdfPage else { return }
+        
+        // We must fetch the view bounds on the main queue
+        var bounds = CGRect.zero
+        DispatchQueue.main.sync { [weak self] in
+            bounds = self?.bounds ?? .zero
+        }
+        
         // Fill the background with white.
         con.setFillColor(red: 1, green: 1, blue: 1, alpha: 1)
         con.fill(bounds)


### PR DESCRIPTION
This fixes #64 was caused by us accessing the view bounds from a background queue. The `draw(_ layer: CALayer, in con: CGContext)` method is called on a background queue. UIKit must always be accessed from the main queue. When we fetch the bounds for filling the background and fixing the rotation, we failed to conform to this rule.

This PR fixes this issue by firstly fetching the bound on the main queue.