### PR TITLE
Ability to reset page (cell) when unpresented

### DIFF
--- a/Sources/Classes/PDFViewController.swift
+++ b/Sources/Classes/PDFViewController.swift
@@ -127,6 +127,9 @@ public final class PDFViewController: UIViewController {
         }
     }
     
+    /// Reset page when its unpresented
+    public var resetZoom: Bool = false
+    
     override public func viewDidLoad() {
         super.viewDidLoad()
     
@@ -278,6 +281,9 @@ extension PDFViewController: UIScrollViewDelegate {
         }
         
         if updatedPageIndex != currentPageIndex {
+            if resetZoom {
+                self.collectionView.reloadItems(at: [IndexPath(item: currentPageIndex, section: 0)])
+            }
             currentPageIndex = updatedPageIndex
             thumbnailCollectionController?.currentPageIndex = currentPageIndex
         }


### PR DESCRIPTION
Here's a small commit to enable cell resets.
E.g. the user zooms, then he swipes to the next page, the former page one is reverted to original format.