### PR TITLE
Add method that allow get currentPageIndex value

### DIFF
--- a/Sources/Classes/PDFViewController.swift
+++ b/Sources/Classes/PDFViewController.swift
@@ -127,6 +127,11 @@ public final class PDFViewController: UIViewController {
         }
     }
     
+    /// Access currentPageIndex
+    public func getCurrentPageIndex() -> Int {
+        return currentPageIndex
+    }
+    
     /// Reset page when its unpresented
     public var resetZoom: Bool = false
     


### PR DESCRIPTION
Hi! 

I liked this project, and start use in personal project. But, sometimes i need get the number of page from viewed PDF. But PDFViewController is has not this possibiliti. So, i created a new method which allow only get the current value of page (`currentIndexPage`), whithout change any other feature. I hope that usefull. I hope did usefull.